### PR TITLE
Update default.py

### DIFF
--- a/plugin.video.tfctv/default.py
+++ b/plugin.video.tfctv/default.py
@@ -6,7 +6,7 @@ import CommonFunctions
 common = CommonFunctions
 thisAddon = xbmcaddon.Addon()
 common.plugin = thisAddon.getAddonInfo('name')
-baseUrl = 'http://tfc.tv'
+baseUrl = 'http://beta.tfc.tv'
 
 # common.dbg = True # Default
 # common.dbglevel = 3 # Default


### PR DESCRIPTION
tfc.tv provider changed their website url from http://tfc.tv to http://beta.tfc.tv. Most kodi tfc tv users living in asia, italy, germany are not able to watch tfc tv on their pc, raspberry, etc..